### PR TITLE
Add Docker test target and document Docker test workflow

### DIFF
--- a/.devcontainer/run-tests.sh
+++ b/.devcontainer/run-tests.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e  # Exit immediately if a command exits with a non-zero status
+
+echo "======================================"
+echo "Running Flake8 linting..."
+echo "======================================"
+uv run flake8 dungeonsheets/ --exit-zero
+
+echo ""
+echo "======================================"
+echo "Testing makesheets (standard)..."
+echo "======================================"
+cd examples/
+uv run makesheets --debug
+
+echo ""
+echo "======================================"
+echo "Testing makesheets (fancy)..."
+echo "======================================"
+uv run makesheets --debug --fancy
+
+echo ""
+echo "======================================"
+echo "Testing makesheets (epub)..."
+echo "======================================"
+uv run makesheets --debug --output-format=epub
+
+echo ""
+echo "======================================"
+echo "Running pytest with coverage..."
+echo "======================================"
+cd ../
+uv run pytest --cov=dungeonsheets tests/
+
+echo ""
+echo "======================================"
+echo "All tests passed successfully!"
+echo "======================================"

--- a/.dockerignore
+++ b/.dockerignore
@@ -119,8 +119,5 @@ ENV/
 
 add_spell.sh
 
-# Not needed for building sheets
+# Not needed for building sheets (but needed for testing)
 characters/
-examples/
-tests/
-docs/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -97,6 +97,38 @@ tests using the *unittest* package in the standard library. **For
 example**, to test a new function in the ``dungeonsheets/dice.py``
 module, modify ``tests/test_dice.py``:
 
+Running Tests with Docker
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To run the complete test suite in a Docker container (matching the CI
+environment), use the ``dungeon-sheets-test`` target:
+
+.. code:: bash
+
+    # Build the test image
+    docker build --target dungeon-sheets-test -t dungeon-sheets-test .
+
+    # Run all tests
+    docker run dungeon-sheets-test
+
+The Docker test container will:
+
+- Run flake8 linting checks
+- Test makesheets with different output formats (standard, fancy, epub)
+- Run the full pytest suite with coverage reporting
+- Display clear section headers for each test phase
+- Exit with code 0 on success, non-zero on failure
+
+You can verify success with:
+
+.. code:: bash
+
+    docker run dungeon-sheets-test && echo "✓ All tests passed!" || echo "✗ Tests failed!"
+
+This approach ensures a consistent test environment with all system
+dependencies (pdftk, texlive) properly installed, which is particularly
+useful for testing on systems where these dependencies are difficult to install.
+
 .. code-block:: python
    :caption: dice.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,3 +109,26 @@ USER $USERNAME
 RUN curl -sS https://starship.rs/install.sh | sh -s -- --yes
 
 COPY .devcontainer/.zshrc /home/$USERNAME/.zshrc
+
+FROM dungeon-sheets-base AS dungeon-sheets-test
+
+# Install uv for fast Python package management
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /workspace
+
+# Copy dependency files
+COPY pyproject.toml uv.lock ./
+
+# Install Python dependencies including dev tools
+RUN uv sync --extra dev
+
+# Copy test script
+COPY .devcontainer/run-tests.sh /usr/local/bin/run-tests.sh
+RUN chmod +x /usr/local/bin/run-tests.sh
+
+# Copy application code
+COPY . /workspace
+
+# Run tests
+CMD ["/usr/local/bin/run-tests.sh"]


### PR DESCRIPTION
## Summary
- add a dedicated `dungeon-sheets-test` Docker build stage based on `dungeon-sheets-base`
- add `.devcontainer/run-tests.sh` to run flake8, makesheets (standard/fancy/epub), and pytest coverage
- document how to build and run the Docker test container in `CONTRIBUTING.rst`
- update `.dockerignore` so test assets (`examples/`, `tests/`, `docs/`) are available in the test image

## Validation
- `docker build --target dungeon-sheets-test -t dungeon-sheets-test .`
- `docker run dungeon-sheets-test`
- Result: `127 passed, 2 skipped`, `95%` coverage