### PR TITLE
Fix Python CI TeX Live install to match Dockerfile (2026)

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -21,13 +21,14 @@ jobs:
     - name: Set up required system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get -y install pdftk wget perl fontconfig
+        sudo apt-get -y install pdftk wget perl fontconfig libwww-perl
     - name: Install minimal TeX Live
       run: |
+        # Keep this installer source and flow aligned with the Dockerfile.
         cd /tmp
-        wget -q https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
-        tar -xzf install-tl-unx.tar.gz
-        cd install-tl-*/
+        wget -q https://tex.org.uk/systems/texlive/tlnet/install-tl-unx.tar.gz
+        zcat < install-tl-unx.tar.gz | tar xf -
+        cd install-tl-2*/
         cat > texlive.profile << 'EOF'
         selected_scheme scheme-basic
         TEXDIR /usr/local/texlive
@@ -41,7 +42,7 @@ jobs:
         option_src 0
         instopt_adjustpath 1
         EOF
-        sudo perl ./install-tl --profile=texlive.profile --no-interaction --repository https://mirror.ctan.org/systems/texlive/tlnet
+        sudo perl ./install-tl --profile=texlive.profile --no-interaction --repository https://tex.org.uk/systems/texlive/tlnet/
         export PATH="/usr/local/texlive/bin/x86_64-linux:$PATH"
         echo "/usr/local/texlive/bin/x86_64-linux" | sudo tee -a $GITHUB_PATH
         # Install required LaTeX packages


### PR DESCRIPTION
This PR updates the Python CI workflow to use the same TeX Live installer source and extraction flow as the Dockerfile, switching from the rolling mirror.ctan.org redirector to the direct tex.org.uk source. This prevents annual release window failures and keeps CI stable during TeX Live rollovers.

- Updated .github/workflows/python-ci.yml to match Dockerfile TeX Live install
- Added libwww-perl to system dependencies for parity
- Added inline note to keep Python CI and Dockerfile aligned

Fixes #39