### PR TITLE
feat: add YAML loader for monsters

### DIFF
--- a/dungeonsheets/yaml_content.py
+++ b/dungeonsheets/yaml_content.py
@@ -1,5 +1,6 @@
 """Helpers for loading canonical content definitions from YAML files."""
 
+import re
 from pathlib import Path
 
 import yaml
@@ -47,6 +48,69 @@ def _load_yaml_list_entries(yaml_file, content_label):
     if not isinstance(raw_data, list):
         raise ValueError(f"Expected a list of {content_label} definitions in {yaml_file}")
     return raw_data
+
+
+def _parse_monster_speeds(speed_str):
+    """Parse a speed string into component speed fields.
+
+    Parameters
+    ----------
+    speed_str : str
+        Speed string from YAML, e.g. ``"30 ft."`` or ``"40 ft., fly 80 ft., swim 30 ft."``.
+
+    Returns
+    -------
+    dict
+        Keys: ``speed``, ``fly_speed``, ``swim_speed``, ``climb_speed``, ``burrow_speed``
+        (all integers).
+    """
+    result = {"speed": 0, "fly_speed": 0, "swim_speed": 0, "climb_speed": 0, "burrow_speed": 0}
+    if not speed_str:
+        return result
+    named = re.compile(r"(fly|swim|climb|burrow)\s+(\d+)", re.IGNORECASE)
+    for match in named.finditer(speed_str):
+        kind, value = match.group(1).lower(), int(match.group(2))
+        result[f"{kind}_speed"] = value
+    base = re.match(r"(\d+)", speed_str)
+    if base:
+        result["speed"] = int(base.group(1))
+    return result
+
+
+def _build_monster_docstring(description, traits, actions, legendary_actions, reactions):
+    """Build a structured monster docstring matching the format used by Python monster classes.
+
+    The format mirrors the existing docstrings in the ``monsters_*.py`` files:
+    description text, then traits, then a ``# Actions`` section divider, then
+    actions, and optionally ``# Legendary Actions`` and ``# Reactions`` sections.
+
+    Parameters
+    ----------
+    description : str
+    traits : list[dict]
+    actions : list[dict]
+    legendary_actions : list[dict]
+    reactions : list[dict]
+
+    Returns
+    -------
+    str
+    """
+    parts = [description or ""]
+    for trait in traits:
+        parts.append(f"\n{trait['name']}.\n  {trait['description']}")
+    parts.append("\n# Actions")
+    for action in actions:
+        parts.append(f"\n{action['name']}.\n  {action['description']}")
+    if legendary_actions:
+        parts.append("\n# Legendary Actions")
+        for la in legendary_actions:
+            parts.append(f"\n{la['name']}.\n  {la['description']}")
+    if reactions:
+        parts.append("\n# Reactions")
+        for reaction in reactions:
+            parts.append(f"\n{reaction['name']}.\n  {reaction['description']}")
+    return "\n".join(parts)
 
 
 def load_yaml_background_classes(yaml_path, base_class, features_module, module=None):
@@ -209,22 +273,52 @@ def load_yaml_monster_classes(yaml_path, base_class, module=None):
             for list_field in ("traits", "actions", "legendary_actions", "reactions"):
                 _validate_list_field(entry, list_field, yaml_file)
 
+            description_text = entry.get(
+                "description", f"{entry.get('name', class_name)} monster loaded from YAML."
+            )
+            traits_list = [
+                {"name": t.get("name", ""), "description": t.get("description", "")}
+                for t in entry.get("traits", [])
+            ]
+            actions_list = [
+                {"name": a.get("name", ""), "description": a.get("description", "")}
+                for a in entry.get("actions", [])
+            ]
+            legendary_actions_list = [
+                {"name": la.get("name", ""), "description": la.get("description", "")}
+                for la in entry.get("legendary_actions", [])
+            ]
+            reactions_list = [
+                {"name": r.get("name", ""), "description": r.get("description", "")}
+                for r in entry.get("reactions", [])
+            ]
+            speeds = _parse_monster_speeds(entry.get("speed", ""))
+
             attrs = {
-                "__doc__": entry.get(
-                    "description", f"{entry.get('name', class_name)} monster loaded from YAML."
+                "description": description_text,
+                "__doc__": _build_monster_docstring(
+                    description_text,
+                    traits_list,
+                    actions_list,
+                    legendary_actions_list,
+                    reactions_list,
                 ),
                 "name": entry.get("name", class_name),
                 "challenge_rating": entry.get("challenge_rating", 0),
                 "armor_class": entry.get("armor_class", 10),
                 "hp_max": entry.get("hp_max", 1),
-                "speed": entry.get("speed", "30 ft."),
+                "speed": speeds["speed"],
+                "fly_speed": speeds["fly_speed"],
+                "swim_speed": speeds["swim_speed"],
+                "climb_speed": speeds["climb_speed"],
+                "burrow_speed": speeds["burrow_speed"],
                 "strength": Ability(int(entry.get("strength", 10))),
                 "dexterity": Ability(int(entry.get("dexterity", 10))),
                 "constitution": Ability(int(entry.get("constitution", 10))),
                 "intelligence": Ability(int(entry.get("intelligence", 10))),
                 "wisdom": Ability(int(entry.get("wisdom", 10))),
                 "charisma": Ability(int(entry.get("charisma", 10))),
-                "skills": entry.get("skill_str", ""),
+                "skills": entry.get("skills", entry.get("skill_str", "")),
                 "saving_throws": entry.get("saving_throws", ""),
                 "damage_immunities": entry.get("damage_immunities", ""),
                 "damage_resistances": entry.get("damage_resistances", ""),
@@ -232,25 +326,16 @@ def load_yaml_monster_classes(yaml_path, base_class, module=None):
                 "condition_immunities": entry.get("condition_immunities", ""),
                 "senses": entry.get("senses", ""),
                 "languages": entry.get("languages", ""),
-                "traits": [
-                    {"name": t.get("name", ""), "description": t.get("description", "")}
-                    for t in entry.get("traits", [])
-                ],
-                "actions": [
-                    {"name": a.get("name", ""), "description": a.get("description", "")}
-                    for a in entry.get("actions", [])
-                ],
-                "legendary_actions": [
-                    {"name": la.get("name", ""), "description": la.get("description", "")}
-                    for la in entry.get("legendary_actions", [])
-                ],
-                "reactions": [
-                    {"name": r.get("name", ""), "description": r.get("description", "")}
-                    for r in entry.get("reactions", [])
-                ],
+                "traits": traits_list,
+                "actions": actions_list,
+                "legendary_actions": legendary_actions_list,
+                "reactions": reactions_list,
                 "data_source": "yaml",
             }
-            attrs["__module__"] = module if module is not None else __name__
+            if module is not None:
+                attrs["__module__"] = module
+            else:
+                attrs["__module__"] = __name__
             generated_classes[class_name] = type(class_name, (base_class,), attrs)
 
     return generated_classes

--- a/tests/fixtures/monsters_test.yaml
+++ b/tests/fixtures/monsters_test.yaml
@@ -11,7 +11,7 @@
   intelligence: 10
   wisdom: 8
   charisma: 8
-  skill_str: "Stealth +6"
+  skills: "Stealth +6"
   saving_throws: ""
   senses: "Darkvision 60 ft., Passive Perception 9"
   languages: "Common, Goblin"
@@ -29,7 +29,7 @@
   intelligence: 5
   wisdom: 7
   charisma: 7
-  skill_str: ""
+  skills: ""
   saving_throws: ""
   damage_resistances: ""
   senses: "Darkvision 60 ft., Passive Perception 8"
@@ -56,7 +56,7 @@
   intelligence: 18
   wisdom: 15
   charisma: 23
-  skill_str: "Perception +16, Stealth +7"
+  skills: "Perception +16, Stealth +7"
   saving_throws: "Dex +7, Con +16, Wis +9, Cha +13"
   damage_immunities: "fire"
   senses: "Blindsight 60 ft., Darkvision 120 ft., Passive Perception 26"

--- a/tests/test_monsters_yaml.py
+++ b/tests/test_monsters_yaml.py
@@ -49,7 +49,25 @@ class TestLoadYamlMonsterClassesScalars(TestCase):
         self.assertEqual(self.classes["TestGoblin"].hp_max, 7)
 
     def test_goblin_speed(self):
-        self.assertEqual(self.classes["TestGoblin"].speed, "30 ft.")
+        self.assertEqual(self.classes["TestGoblin"].speed, 30)
+
+    def test_goblin_description(self):
+        self.assertEqual(self.classes["TestGoblin"].description, "Small humanoid (goblinoid), neutral evil")
+
+    def test_goblin_docstring_has_actions_section(self):
+        self.assertIn("# Actions", self.classes["TestGoblin"].__doc__)
+
+    def test_dragon_base_speed_is_integer(self):
+        self.assertEqual(self.classes["TestAncientDragon"].speed, 40)
+
+    def test_dragon_fly_speed(self):
+        self.assertEqual(self.classes["TestAncientDragon"].fly_speed, 80)
+
+    def test_dragon_climb_speed(self):
+        self.assertEqual(self.classes["TestAncientDragon"].climb_speed, 40)
+
+    def test_goblin_swim_speed_defaults_to_zero(self):
+        self.assertEqual(self.classes["TestGoblin"].swim_speed, 0)
 
     def test_goblin_ability_scores(self):
         goblin = self.classes["TestGoblin"]()


### PR DESCRIPTION
Closes #68

Adds \load_yaml_monster_classes()\ to \yaml_content.py\ with support for the full monster schema (ability scores, traits, actions, legendary actions, reactions, etc.).

Includes fixture YAML and tests. Prerequisite for #69.

Part of #47.