### PR TITLE
fix: open JSON character files with utf-8 encoding

### DIFF
--- a/dungeonsheets/readers.py
+++ b/dungeonsheets/readers.py
@@ -111,7 +111,7 @@ class JSONCharacterReader(BaseCharacterReader):
     @lru_cache()
     def json_data(self):
         # Load the JSON data from disk
-        with open(self.filename, mode="r") as fp:
+        with open(self.filename, mode="r", encoding="utf-8") as fp:
             data = json.load(fp)
         return data
 


### PR DESCRIPTION
Fixes a pre-existing UnicodeDecodeError on Windows where \open()\ defaults to \cp1252\. JSON files must be read as UTF-8 per the JSON spec. Resolves 3 failing tests in \	est_readers.py\ on Windows.