### PR TITLE
latex: prevent TEXINPUTS env leak across renders

### DIFF
--- a/dungeonsheets/latex.py
+++ b/dungeonsheets/latex.py
@@ -105,7 +105,7 @@ def create_latex_pdf(
         str(tex_file),
     ]
 
-    environment = os.environ
+    environment = os.environ.copy()
     tex_env = environment.get("TEXINPUTS", "")
     module_root = Path(__file__).parent / "modules/"
     module_dirs = [module_root / mdir for mdir in ["DND-5e-LaTeX-Template"]]


### PR DESCRIPTION
## Summary
Fixes a small but important environment-leak bug in LaTeX PDF generation.

## Change
- In `create_latex_pdf()` (`dungeonsheets/latex.py`), switch:
  - `environment = os.environ`
  - to `environment = os.environ.copy()`

This scopes `TEXINPUTS` modifications to the subprocess environment and prevents accidental global process environment mutation across subsequent renders.

## Validation
- Local Docker validation run before push:
  - `docker build --target dungeon-sheets -t dungeon-sheets:local .`
  - `docker run --rm -v "$PWD/examples:/build" dungeon-sheets:local --debug`

## Tracking
Contributes to #19.
