### PR TITLE
fix: improve error diagnostics for --tex-template missing template assets (#91)

### DIFF
--- a/dungeonsheets/latex.py
+++ b/dungeonsheets/latex.py
@@ -22,6 +22,32 @@ def _split_env_paths(raw_value: str, separator: str) -> list[str]:
     return [part for part in raw_value.split(separator) if part]
 
 
+def _tex_template_hint(module_root: Path, tex_error_msg: str | None) -> str:
+    """Build a targeted hint when tex-template assets are missing."""
+    if not tex_error_msg or "dnd.sty" not in tex_error_msg:
+        return ""
+
+    dnd_template_root = module_root / "DND-5e-LaTeX-Template"
+    character_sheet_root = module_root / "DND-5e-LaTeX-Character-Sheet-Template"
+    expected_paths = [
+        dnd_template_root,
+        dnd_template_root / "dnd.sty",
+        character_sheet_root,
+        character_sheet_root / "dndtemplate.sty",
+    ]
+    missing_paths = [str(path) for path in expected_paths if not path.exists()]
+
+    hint = (
+        " tex-template assets appear unavailable"
+        f" under {module_root}."
+        " Ensure template modules are present"
+        " (for git checkouts: git submodule update --init --recursive)."
+    )
+    if missing_paths:
+        hint += f" Missing paths: {', '.join(missing_paths)}."
+    return hint
+
+
 class LatexWriter(Writer):
     def __init__(self):
         super().__init__()
@@ -117,6 +143,8 @@ def create_latex_pdf(
     environment = os.environ.copy()
     tex_env = environment.get("TEXINPUTS", "")
     module_root = Path(__file__).parent / "modules/"
+    dnd_template_root = module_root / "DND-5e-LaTeX-Template"
+    character_sheet_root = module_root / "DND-5e-LaTeX-Character-Sheet-Template"
     module_dirs = [module_root / mdir for mdir in ["DND-5e-LaTeX-Template"]]
     log.debug(f"Loading additional modules from {module_dirs}.")
     separator = ";" if isinstance(module_root, pathlib.WindowsPath) else ":"
@@ -127,8 +155,6 @@ def create_latex_pdf(
         # LuaHBTeX on TeX Live 2026 can fail in luaotfload startup with broad
         # recursive TEXINPUTS/TTFONTS overrides. Keep a narrow, non-recursive
         # TEXINPUTS for template assets and preserve default search paths.
-        dnd_template_root = module_root / "DND-5e-LaTeX-Template"
-        character_sheet_root = module_root / "DND-5e-LaTeX-Character-Sheet-Template"
         # Run from the character-sheet template root so dndtemplate's relative
         # font path (template/fonts) resolves correctly.
         latex_working_dir = character_sheet_root
@@ -182,6 +208,8 @@ def create_latex_pdf(
                 err_msg = f"Processing of {basename}.tex failed. See {logfile} for details."
                 # Load the log file for more details
                 tex_error_msg = tex_error(logfile)
+                if use_tex_template:
+                    err_msg += _tex_template_hint(module_root, tex_error_msg)
                 if tex_error_msg:
                     for line in tex_error_msg.split("\n"):
                         log.error(line)

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -1,10 +1,10 @@
-import unittest
 import tempfile
+import unittest
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from dungeonsheets import spells, features, latex
+from dungeonsheets import exceptions, features, latex, spells
 
 
 class MarkdownTestCase(unittest.TestCase):
@@ -31,36 +31,28 @@ class MarkdownTestCase(unittest.TestCase):
         text = latex.rst_to_latex(r"\\")
         self.assertEqual(r"\textbackslash{}", text.strip("\n"))
 
-    @unittest.skip(
-        "Headings are all screwed up because it treats them as the document title"
-    )
+    @unittest.skip("Headings are all screwed up because it treats them as the document title")
     def test_headings(self):
         # Simple heading by itself
-        text = latex.rst_to_latex(
-            "Hello, world\n------------\n\nGoodbye, world")
+        text = latex.rst_to_latex("Hello, world\n------------\n\nGoodbye, world")
         self.assertEqual("\\section*{Hello, world}\n", text)
         # Simple heading with leading whitespace
         text = latex.rst_to_latex("    Hello, world\n    ============\n")
         self.assertEqual("\\section*{Hello, world}\n", text)
         # Heading with text after it
-        text = latex.rst_to_latex(
-            "Hello, world\n============\n\nThis is some text")
+        text = latex.rst_to_latex("Hello, world\n============\n\nThis is some text")
         self.assertEqual("\\section*{Hello, world}\n\nThis is some text", text)
         # Heading with text before it
-        text = latex.rst_to_latex(
-            "This is a paragraph\n\nHello, world\n============\n")
-        self.assertEqual(
-            "This is a paragraph\n\n\\section*{Hello, world}\n", text)
+        text = latex.rst_to_latex("This is a paragraph\n\nHello, world\n============\n")
+        self.assertEqual("This is a paragraph\n\n\\section*{Hello, world}\n", text)
         # Check that levels of headings are parsed appropriately
         text = latex.rst_to_latex("Hello, world\n^^^^^^^^^^^^\n")
         self.assertEqual("\\subsubsection*{Hello, world}\n", text)
-        text = latex.rst_to_latex(
-            "Hello, world\n^^^^^^^^^^^^\n", top_heading_level=3)
+        text = latex.rst_to_latex("Hello, world\n^^^^^^^^^^^^\n", top_heading_level=3)
         self.assertEqual("\\subparagraph*{Hello, world}\n", text)
         # This is a bad heading missing with all the underline on one line
         text = latex.rst_to_latex("Hello, world^^^^^^^^^^^^\n")
-        self.assertEqual(
-            "Hello, world\\^\\^\\^\\^\\^\\^\\^\\^\\^\\^\\^\\^\n", text)
+        self.assertEqual("Hello, world\\^\\^\\^\\^\\^\\^\\^\\^\\^\\^\\^\\^\n", text)
 
     def test_bullet_list(self):
         tex = latex.rst_to_latex("\n- Hello\n- World\n\n")
@@ -130,9 +122,7 @@ class MarkdownTestCase(unittest.TestCase):
     def test_rst_all_spells(self):
         for spell in spells.all_spells():
             tex = latex.rst_to_latex(spell.__doc__)
-            self.assertNotIn(
-                "DUadmonition", tex, f"spell {spell} is not valid reStructured text"
-            )
+            self.assertNotIn("DUadmonition", tex, f"spell {spell} is not valid reStructured text")
 
     def test_rst_all_features(self):
         for feature in features.all_features():
@@ -199,3 +189,51 @@ class LatexEnvTestCase(unittest.TestCase):
         self.assertIn("TEXINPUTS", captured_env)
         self.assertNotIn("::", captured_env["TEXINPUTS"])
         self.assertIn("/tmp/tex", captured_env["TEXINPUTS"])
+
+
+class LatexErrorHintTestCase(unittest.TestCase):
+    def test_tex_template_missing_style_adds_actionable_hint(self):
+        with tempfile.TemporaryDirectory() as td:
+            basename = str(Path(td) / "missing_style")
+            with (
+                patch(
+                    "dungeonsheets.latex.subprocess.run",
+                    return_value=SimpleNamespace(returncode=1),
+                ),
+                patch(
+                    "dungeonsheets.latex.tex_error",
+                    return_value="! LaTeX Error: File `dnd.sty' not found.",
+                ),
+            ):
+                with self.assertRaises(exceptions.LatexError) as ctx:
+                    latex.create_latex_pdf(
+                        tex="\\documentclass{article}\\begin{document}x\\end{document}",
+                        basename=basename,
+                        use_tex_template=True,
+                    )
+
+        error_message = str(ctx.exception)
+        self.assertIn("tex-template assets appear unavailable", error_message)
+        self.assertIn("git submodule update --init --recursive", error_message)
+
+    def test_non_template_error_does_not_add_hint(self):
+        with tempfile.TemporaryDirectory() as td:
+            basename = str(Path(td) / "generic_error")
+            with (
+                patch(
+                    "dungeonsheets.latex.subprocess.run",
+                    return_value=SimpleNamespace(returncode=1),
+                ),
+                patch(
+                    "dungeonsheets.latex.tex_error",
+                    return_value="! LaTeX Error: Undefined control sequence.",
+                ),
+            ):
+                with self.assertRaises(exceptions.LatexError) as ctx:
+                    latex.create_latex_pdf(
+                        tex="\\documentclass{article}\\begin{document}x\\end{document}",
+                        basename=basename,
+                        use_tex_template=True,
+                    )
+
+        self.assertNotIn("git submodule update --init --recursive", str(ctx.exception))


### PR DESCRIPTION
## Summary

Closes #91

When `--tex-template` fails because the `dnd.sty` style file cannot be found (e.g. the template git submodules have not been initialised), the `LatexError` message now includes an actionable diagnostic hint:

- States that tex-template assets appear unavailable under the modules path
- Lists the specific missing paths
- Tells the user exactly how to fix it: `git submodule update --init --recursive`

Non-template errors and non-`dnd.sty`-related template errors are unaffected — the hint is only injected when `use_tex_template=True` and the log contains `dnd.sty`.

## Root Cause

The `DND-5e-LaTeX-Template` and `DND-5e-LaTeX-Character-Sheet-Template` directories under `dungeonsheets/modules/` are git submodules. If a user clones the repo without `--recurse-submodules` (or without running `git submodule update --init --recursive`), these dirs will be empty. `lualatex` then fails immediately with `File dnd.sty not found`, but the original error message only said _"See fighter1_char.log for details"_ — giving no path to resolution.

## Changes

| File | Change |
|---|---|
| `dungeonsheets/latex.py` | Added `_tex_template_hint()` helper; called when `use_tex_template=True` and tex error log contains `dnd.sty`; also hoisted `dnd_template_root`/`character_sheet_root` to function scope to avoid duplication |
| `tests/test_latex.py` | Added `LatexErrorHintTestCase` with two regression tests: one confirms the actionable hint appears for `dnd.sty` failures, one confirms it does not appear for unrelated LaTeX errors |

## Testing

- Docker pytest: 255 passed, 0 failed (all tests)
- Focused latex env + new regression tests: 4/4 passed in Docker
- Runtime Docker validation against `examples/fighter1.py` with `--fancy --paper-size a4 --output-format pdf --tex-template`: passes (submodules present)
- Runtime Docker validation against real user campaign sheets (Neverwinter Warriors): all 7 character sheets rendered successfully with only expected content warnings (unknown gear/magic items)
- Confirmed `bard1_features` standard lualatex failure is **pre-existing on main** (unrelated to this PR)