### PR TITLE
ci: audit and upgrade GitHub Actions versions (#81)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,16 +21,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build test image with cache
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: dungeon-sheets
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload generated LaTeX artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docker-latex-debug-artifacts
           if-no-files-found: ignore
@@ -96,21 +96,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -118,12 +118,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -132,7 +132,7 @@ jobs:
       with:
         python-version: '3.13'
     - name: Install uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         enable-cache: true
     - name: Install dependencies with uv

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
     - name: Set up required system dependencies
@@ -54,11 +54,11 @@ jobs:
         sudo /usr/local/texlive/bin/x86_64-linux/tlmgr install $PACKAGES
         sudo fc-cache -fv
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8
       with:
         enable-cache: true
     - name: Install dependencies with uv
@@ -93,7 +93,7 @@ jobs:
         build-command: ["", "--fancy --spells-by-level", "--output-format=epub"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
     - name: Set up required system dependencies
@@ -128,11 +128,11 @@ jobs:
         sudo /usr/local/texlive/bin/x86_64-linux/tlmgr install $PACKAGES
         sudo fc-cache -fv
     - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8
       with:
         enable-cache: true
     - name: Install dependencies with uv

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -58,7 +58,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         enable-cache: true
     - name: Install dependencies with uv


### PR DESCRIPTION
## Summary

Maintenance-only CI upgrade pass for issue #81.

Upgraded GitHub Actions references across both workflow files to the latest stable major releases available at audit time, without changing workflow logic.

## Action Version Audit

Queried latest upstream release tags via GitHub API and upgraded where newer stable majors existed.

### Updated in `.github/workflows/python-ci.yml`
- `actions/checkout`: `v4` -> `v6`
- `actions/setup-python`: `v5` -> `v6`
- `astral-sh/setup-uv`: `v5` -> `v8`

### Updated in `.github/workflows/docker.yml`
- `actions/checkout`: `v4` -> `v6`
- `docker/setup-buildx-action`: `v3` -> `v4`
- `docker/build-push-action`: `v5` -> `v7`
- `actions/upload-artifact`: `v4` -> `v7`
- `docker/setup-qemu-action`: `v3` -> `v4`
- `docker/login-action`: `v3` -> `v4`
- `docker/metadata-action`: `v5` -> `v6`

## Validation

- Ran workflow linting in Docker using `rhysd/actionlint`.
- Result: no workflow syntax/action-reference failures related to these upgrades.
- Note: existing ShellCheck info-level messages (SC2086) in TeX install scripts are pre-existing and intentionally out of scope for this version-only upgrade PR.

## Scope Guardrails

- No workflow behavior changes
- No command/script logic changes
- No application code/test changes

Refs #81