### PR TITLE
perf: lazy-load YAML content registration (#79)

### DIFF
--- a/dungeonsheets/armor.py
+++ b/dungeonsheets/armor.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+from importlib.resources import files
 
 from dungeonsheets.content_registry import default_content_registry
 from dungeonsheets.yaml_content import load_yaml_armor_classes
@@ -122,21 +122,50 @@ class HeavyArmor(Armor):
 # ---------------------------------------------------------------------------
 # Load all concrete armor definitions from YAML
 # ---------------------------------------------------------------------------
-_yaml_armors = load_yaml_armor_classes(
-    Path(__file__).with_name("data") / "armor.yaml",
-    Armor,
-    type_map={
-        "light": LightArmor,
-        "medium": MediumArmor,
-        "heavy": HeavyArmor,
-    },
-    module=__name__,
-)
-globals().update(_yaml_armors)
+_yaml_loaded = False
 
-light_armors = [_yaml_armors[n] for n in ("PaddedArmor", "LeatherArmor", "StuddedLeatherArmor")]
-medium_armors = [
-    _yaml_armors[n] for n in ("HideArmor", "ChainShirt", "ScaleMail", "Breastplate", "HalfPlate")
-]
-heavy_armors = [_yaml_armors[n] for n in ("RingMail", "ChainMail", "SplintArmor", "PlateMail")]
-all_armors = light_armors + medium_armors + heavy_armors
+
+def _load_yaml_content():
+    global _yaml_loaded
+    if _yaml_loaded:
+        return
+
+    yaml_armors = load_yaml_armor_classes(
+        files("dungeonsheets.data").joinpath("armor.yaml"),
+        Armor,
+        type_map={
+            "light": LightArmor,
+            "medium": MediumArmor,
+            "heavy": HeavyArmor,
+        },
+        module=__name__,
+    )
+    globals().update(yaml_armors)
+
+    globals()["light_armors"] = [
+        yaml_armors[n] for n in ("PaddedArmor", "LeatherArmor", "StuddedLeatherArmor")
+    ]
+    globals()["medium_armors"] = [
+        yaml_armors[n] for n in ("HideArmor", "ChainShirt", "ScaleMail", "Breastplate", "HalfPlate")
+    ]
+    globals()["heavy_armors"] = [
+        yaml_armors[n] for n in ("RingMail", "ChainMail", "SplintArmor", "PlateMail")
+    ]
+    globals()["all_armors"] = (
+        globals()["light_armors"] + globals()["medium_armors"] + globals()["heavy_armors"]
+    )
+
+    _yaml_loaded = True
+
+
+def __getattr__(name):
+    _load_yaml_content()
+    try:
+        return globals()[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+
+def __dir__():
+    _load_yaml_content()
+    return sorted(globals())

--- a/dungeonsheets/background.py
+++ b/dungeonsheets/background.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+from importlib.resources import files
 
 from dungeonsheets import features as feats
 from dungeonsheets.content_registry import default_content_registry
@@ -285,57 +285,127 @@ class Faceless(Background):
     features = (feats.FacelessPersona, feats.DualPersonalities)
 
 
-globals().update(
-    load_yaml_background_classes(
-        Path(__file__).with_name("data").joinpath("backgrounds.yaml"),
+_yaml_loaded = False
+
+
+_LEGACY_BACKGROUNDS = {
+    name: obj
+    for name, obj in list(globals().items())
+    if isinstance(obj, type) and issubclass(obj, Background) and obj is not Background
+}
+
+# Remove concrete background class bindings so first access triggers __getattr__
+# and loads YAML-backed classes before exposing legacy fallbacks.
+for _name in _LEGACY_BACKGROUNDS:
+    globals().pop(_name, None)
+
+
+def _load_yaml_content():
+    global _yaml_loaded
+    if _yaml_loaded:
+        return
+
+    generated = load_yaml_background_classes(
+        files("dungeonsheets.data").joinpath("backgrounds.yaml"),
         Background,
         feats,
         module=__name__,
     )
-)
+
+    globals().update(_LEGACY_BACKGROUNDS)
+    globals().update(generated)
+
+    globals()["PHB_backgrounds"] = [
+        globals()[name]
+        for name in (
+            "Acolyte",
+            "Charlatan",
+            "Criminal",
+            "Spy",
+            "Entertainer",
+            "Gladiator",
+            "Farmer",
+            "FolkHero",
+            "GuildArtisan",
+            "GuildMerchant",
+            "Hermit",
+            "Noble",
+            "Knight",
+            "Outlander",
+            "Sage",
+            "Sailor",
+            "Pirate",
+            "Soldier",
+            "Urchin",
+        )
+    ]
+    globals()["SCAG_backgrounds"] = [
+        globals()[name]
+        for name in (
+            "CityWatch",
+            "ClanCrafter",
+            "CloisteredScholar",
+            "Courtier",
+            "FactionAgent",
+            "FarTraveler",
+            "Inheritor",
+            "KnightOfTheOrder",
+            "MercenaryVeteran",
+            "UrbanBountyHunter",
+            "UthgardtTribeMember",
+            "WaterdhavianNoble",
+        )
+    ]
+    globals()["available_backgrounds"] = (
+        globals()["PHB_backgrounds"] + globals()["SCAG_backgrounds"]
+    )
+
+    _yaml_loaded = True
 
 
-PHB_backgrounds = [
-    Acolyte,
-    Charlatan,
-    Criminal,
-    Spy,
-    Entertainer,
-    Gladiator,
-    Farmer,
-    FolkHero,
-    GuildArtisan,
-    GuildMerchant,
-    Hermit,
-    Noble,
-    Knight,
-    Outlander,
-    Sage,
-    Sailor,
-    Pirate,
-    Soldier,
-    Urchin,
-]
+def __getattr__(name):
+    _load_yaml_content()
+    try:
+        return globals()[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
 
-SCAG_backgrounds = [
-    CityWatch,
-    ClanCrafter,
-    CloisteredScholar,
-    Courtier,
-    FactionAgent,
-    FarTraveler,
-    Inheritor,
-    KnightOfTheOrder,
-    MercenaryVeteran,
-    UrbanBountyHunter,
-    UthgardtTribeMember,
-    WaterdhavianNoble,
-]
 
-available_backgrounds = PHB_backgrounds + SCAG_backgrounds
+def __dir__():
+    _load_yaml_content()
+    return sorted(globals())
 
-__all__ = tuple([b.name for b in available_backgrounds]) + (
-    "PHB_backgrounds",
-    "SCAG_backgrounds",
-    "available_backgrounds",
+
+__all__ = (
+    "Acolyte",
+    "Charlatan",
+    "Criminal",
+    "Spy",
+    "Entertainer",
+    "Gladiator",
+    "Farmer",
+    "FolkHero",
+    "GuildArtisan",
+    "GuildMerchant",
+    "Hermit",
+    "Noble",
+    "Knight",
+    "Outlander",
+    "Sage",
+    "Sailor",
+    "Pirate",
+    "Soldier",
+    "Urchin",
+    "CityWatch",
+    "ClanCrafter",
+    "CloisteredScholar",
+    "Courtier",
+    "FactionAgent",
+    "FarTraveler",
+    "Inheritor",
+    "KnightOfTheOrder",
+    "MercenaryVeteran",
+    "UrbanBountyHunter",
+    "UthgardtTribeMember",
+    "WaterdhavianNoble",
 )

--- a/dungeonsheets/background.py
+++ b/dungeonsheets/background.py
@@ -376,7 +376,7 @@ def __dir__():
     return sorted(globals())
 
 
-__all__ = (
+_PUBLIC_EXPORTS = (
     "Acolyte",
     "Charlatan",
     "Criminal",
@@ -408,4 +408,9 @@ __all__ = (
     "UrbanBountyHunter",
     "UthgardtTribeMember",
     "WaterdhavianNoble",
+    "PHB_backgrounds",
+    "SCAG_backgrounds",
+    "available_backgrounds",
 )
+
+__all__ = _PUBLIC_EXPORTS

--- a/dungeonsheets/monsters/__init__.py
+++ b/dungeonsheets/monsters/__init__.py
@@ -1,18 +1,52 @@
-from pathlib import Path
+from importlib.resources import files
 
 from dungeonsheets.content_registry import default_content_registry
 from dungeonsheets.monsters.monsters import *
 from dungeonsheets.monsters.monsters import Monster
 from dungeonsheets.yaml_content import load_yaml_monster_classes
 
-_DATA_DIR = Path(__file__).resolve().parent.parent / "data" / "monsters"
+_yaml_loaded = False
 
-globals().update(
-    load_yaml_monster_classes(
-        _DATA_DIR,
+
+_LEGACY_MONSTER_CLASSES = {
+    name: obj
+    for name, obj in list(globals().items())
+    if isinstance(obj, type) and issubclass(obj, Monster) and obj is not Monster
+}
+
+# Remove concrete monster class bindings so first access triggers __getattr__
+# and loads YAML-backed classes before exposing legacy fallbacks.
+for _name in _LEGACY_MONSTER_CLASSES:
+    globals().pop(_name, None)
+
+
+def _load_yaml_content():
+    global _yaml_loaded
+    if _yaml_loaded:
+        return
+
+    generated = load_yaml_monster_classes(
+        files("dungeonsheets.data").joinpath("monsters"),
         Monster,
         module=__name__,
     )
-)
+    globals().update(_LEGACY_MONSTER_CLASSES)
+    globals().update(generated)
+
+    _yaml_loaded = True
+
+
+def __getattr__(name):
+    _load_yaml_content()
+    try:
+        return globals()[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+
+def __dir__():
+    _load_yaml_content()
+    return sorted(globals())
+
 
 default_content_registry.add_module(__name__)

--- a/dungeonsheets/spells/__init__.py
+++ b/dungeonsheets/spells/__init__.py
@@ -1,22 +1,49 @@
-from pathlib import Path
+from importlib.resources import files
 
 from dungeonsheets.content_registry import default_content_registry
-from dungeonsheets.spells.spells import Spell, all_spells, create_spell
+from dungeonsheets.spells.spells import Spell, create_spell
+from dungeonsheets.spells.spells import all_spells as _all_spells
 from dungeonsheets.yaml_content import load_yaml_spell_classes
 
-_DATA_DIR = Path(__file__).resolve().parent.parent.joinpath("data")
-_SPELLS_YAML_SOURCE = (
-    _DATA_DIR.joinpath("spells")
-    if _DATA_DIR.joinpath("spells").is_dir()
-    else _DATA_DIR.joinpath("spells.yaml")
-)
+_yaml_loaded = False
 
-globals().update(
-    load_yaml_spell_classes(
-        _SPELLS_YAML_SOURCE,
-        Spell,
-        module=__name__,
+
+def _load_yaml_content():
+    global _yaml_loaded
+    if _yaml_loaded:
+        return
+
+    data_dir = files("dungeonsheets.data")
+    spells_source = data_dir.joinpath("spells")
+    if not spells_source.is_dir():
+        spells_source = data_dir.joinpath("spells.yaml")
+
+    globals().update(
+        load_yaml_spell_classes(
+            spells_source,
+            Spell,
+            module=__name__,
+        )
     )
-)
+    _yaml_loaded = True
+
+
+def all_spells():
+    _load_yaml_content()
+    return _all_spells()
+
+
+def __getattr__(name):
+    _load_yaml_content()
+    try:
+        return globals()[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+
+def __dir__():
+    _load_yaml_content()
+    return sorted(globals())
+
 
 default_content_registry.add_module(__name__)

--- a/dungeonsheets/weapons.py
+++ b/dungeonsheets/weapons.py
@@ -1,11 +1,9 @@
-from pathlib import Path
+from importlib.resources import files
 
 from dungeonsheets.content_registry import default_content_registry
 from dungeonsheets.yaml_content import load_yaml_weapon_classes
 
 default_content_registry.add_module(__name__)
-
-_DATA_DIR = Path(__file__).parent / "data"
 
 
 class Weapon:
@@ -139,39 +137,6 @@ _TYPE_MAP = {
     "unarmed": (Unarmed,),
 }
 
-_generated = load_yaml_weapon_classes(
-    _DATA_DIR / "weapons.yaml",
-    Weapon,
-    type_map=_TYPE_MAP,
-    module=__name__,
-)
-globals().update(_generated)
-
-# Category tuples rebuilt from loaded classes so existing proficiency checks work.
-simple_melee_weapons = tuple(
-    cls
-    for cls in _generated.values()
-    if issubclass(cls, SimpleWeapon) and issubclass(cls, MeleeWeapon)
-)
-simple_ranged_weapons = tuple(
-    cls
-    for cls in _generated.values()
-    if issubclass(cls, SimpleWeapon) and issubclass(cls, RangedWeapon)
-)
-simple_weapons = simple_melee_weapons + simple_ranged_weapons
-
-martial_melee_weapons = tuple(
-    cls
-    for cls in _generated.values()
-    if issubclass(cls, MartialWeapon) and issubclass(cls, MeleeWeapon)
-)
-martial_ranged_weapons = tuple(
-    cls
-    for cls in _generated.values()
-    if issubclass(cls, MartialWeapon) and issubclass(cls, RangedWeapon)
-)
-martial_weapons = martial_melee_weapons + martial_ranged_weapons
-
 _MONK_WEAPON_NAMES = frozenset(
     (
         "Shortsword",
@@ -187,8 +152,71 @@ _MONK_WEAPON_NAMES = frozenset(
         "SunBolt",
     )
 )
-monk_weapons = (Unarmed,) + tuple(
-    cls for name, cls in _generated.items() if name in _MONK_WEAPON_NAMES
-)
 
-firearms = (Firearm,) + tuple(cls for cls in _generated.values() if issubclass(cls, Firearm))
+_DATA_DIR = files("dungeonsheets.data")
+_yaml_loaded = False
+
+
+def _load_yaml_content():
+    global _yaml_loaded
+    if _yaml_loaded:
+        return
+
+    generated = load_yaml_weapon_classes(
+        _DATA_DIR.joinpath("weapons.yaml"),
+        Weapon,
+        type_map=_TYPE_MAP,
+        module=__name__,
+    )
+    globals().update(generated)
+
+    # Category tuples rebuilt from loaded classes so existing proficiency checks work.
+    globals()["simple_melee_weapons"] = tuple(
+        cls
+        for cls in generated.values()
+        if issubclass(cls, SimpleWeapon) and issubclass(cls, MeleeWeapon)
+    )
+    globals()["simple_ranged_weapons"] = tuple(
+        cls
+        for cls in generated.values()
+        if issubclass(cls, SimpleWeapon) and issubclass(cls, RangedWeapon)
+    )
+    globals()["simple_weapons"] = (
+        globals()["simple_melee_weapons"] + globals()["simple_ranged_weapons"]
+    )
+
+    globals()["martial_melee_weapons"] = tuple(
+        cls
+        for cls in generated.values()
+        if issubclass(cls, MartialWeapon) and issubclass(cls, MeleeWeapon)
+    )
+    globals()["martial_ranged_weapons"] = tuple(
+        cls
+        for cls in generated.values()
+        if issubclass(cls, MartialWeapon) and issubclass(cls, RangedWeapon)
+    )
+    globals()["martial_weapons"] = (
+        globals()["martial_melee_weapons"] + globals()["martial_ranged_weapons"]
+    )
+
+    globals()["monk_weapons"] = (Unarmed,) + tuple(
+        cls for name, cls in generated.items() if name in _MONK_WEAPON_NAMES
+    )
+    globals()["firearms"] = (Firearm,) + tuple(
+        cls for cls in generated.values() if issubclass(cls, Firearm)
+    )
+
+    _yaml_loaded = True
+
+
+def __getattr__(name):
+    _load_yaml_content()
+    try:
+        return globals()[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+
+def __dir__():
+    _load_yaml_content()
+    return sorted(globals())

--- a/dungeonsheets/yaml_content.py
+++ b/dungeonsheets/yaml_content.py
@@ -26,8 +26,9 @@ def _resolve_yaml_sources(yaml_path):
 
     Parameters
     ----------
-    yaml_path : PathLike
-        A YAML file path or a directory containing YAML files.
+    yaml_path : PathLike | Traversable
+        A YAML file path, a directory containing YAML files, or an
+        ``importlib.resources`` Traversable representing either.
 
     Returns
     -------

--- a/dungeonsheets/yaml_content.py
+++ b/dungeonsheets/yaml_content.py
@@ -31,14 +31,31 @@ def _resolve_yaml_sources(yaml_path):
 
     Returns
     -------
-    list[Path]
+    list[Path | Traversable]
         Sorted list of YAML files to load.
     """
-    path = Path(yaml_path)
-    if path.is_dir():
-        return sorted(candidate for candidate in path.glob("*.yaml") if candidate.is_file())
-    if path.exists() and path.is_file():
-        return [path]
+    try:
+        path = Path(yaml_path)
+    except TypeError:
+        path = None
+
+    if path is not None:
+        if path.is_dir():
+            return sorted(candidate for candidate in path.glob("*.yaml") if candidate.is_file())
+        if path.exists() and path.is_file():
+            return [path]
+
+    # Support importlib.resources Traversable objects for non-filesystem imports.
+    traversable = yaml_path
+    if hasattr(traversable, "is_dir") and traversable.is_dir():
+        yaml_files = [
+            candidate
+            for candidate in traversable.iterdir()
+            if candidate.is_file() and candidate.name.endswith(".yaml")
+        ]
+        return sorted(yaml_files, key=lambda candidate: candidate.name)
+    if hasattr(traversable, "is_file") and traversable.is_file():
+        return [traversable]
     return []
 
 

--- a/tests/test_yaml_content_loader.py
+++ b/tests/test_yaml_content_loader.py
@@ -1,10 +1,15 @@
+from importlib.resources import files
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 from dungeonsheets.magic_items import MagicItem
 from dungeonsheets.spells.spells import Spell
-from dungeonsheets.yaml_content import load_yaml_magic_item_classes, load_yaml_spell_classes
+from dungeonsheets.yaml_content import (
+    _resolve_yaml_sources,
+    load_yaml_magic_item_classes,
+    load_yaml_spell_classes,
+)
 
 
 class TestSplitYamlLoader(TestCase):
@@ -175,3 +180,17 @@ class TestSplitYamlLoader(TestCase):
                 load_yaml_magic_item_classes(yaml_dir, MagicItem)
 
             self.assertIn("linked_spells", str(ctx.exception))
+
+    def test_resolve_yaml_sources_supports_traversable_directory(self):
+        spells_dir = files("dungeonsheets.data").joinpath("spells")
+        sources = _resolve_yaml_sources(spells_dir)
+
+        self.assertGreater(len(sources), 0)
+        self.assertTrue(all(source.name.endswith(".yaml") for source in sources))
+
+    def test_spell_loader_supports_traversable_directory(self):
+        spells_dir = files("dungeonsheets.data").joinpath("spells")
+        generated = load_yaml_spell_classes(spells_dir, Spell)
+
+        self.assertIn("MagicMissile", generated)
+        self.assertEqual(generated["MagicMissile"].data_source, "yaml")


### PR DESCRIPTION
## Summary
- lazy-load YAML-backed content classes for armor, backgrounds, weapons, spells, and monsters
- preserve existing module APIs by resolving classes on first attribute access
- preserve YAML-over-legacy override behavior for backgrounds and monsters
- add importlib.resources Traversable support in YAML source resolution

## Implementation details
- Added module-level lazy loaders (`_load_yaml_content`) plus `__getattr__` in:
  - `dungeonsheets/armor.py`
  - `dungeonsheets/background.py`
  - `dungeonsheets/weapons.py`
  - `dungeonsheets/spells/__init__.py`
  - `dungeonsheets/monsters/__init__.py`
- Updated `dungeonsheets/yaml_content.py::_resolve_yaml_sources` to support both `Path` and `Traversable` sources.
- Updated spells `all_spells()` export to force-load YAML before enumerating module spell classes.

## Tests
- `uv run pytest tests/test_yaml_content_loader.py tests/test_background_yaml.py tests/test_armor_yaml.py tests/test_weapons_yaml.py tests/test_spells.py tests/test_spells_yaml.py tests/test_monsters_yaml.py`
- `uv run ruff check dungeonsheets/yaml_content.py dungeonsheets/armor.py dungeonsheets/background.py dungeonsheets/monsters/__init__.py dungeonsheets/spells/__init__.py dungeonsheets/weapons.py tests/test_yaml_content_loader.py`
- push-time hooks passed (`ruff` checks + local smoke tests)