### PR TITLE
feat: add Broom of Flying magic item (#44)

### DIFF
--- a/dungeonsheets/data/magic_items.yaml
+++ b/dungeonsheets/data/magic_items.yaml
@@ -258,6 +258,24 @@
   rarity: Uncommon
   requires_attunement: true
 
+- class_name: BroomOfFlying
+  name: Broom of Flying
+  description: |
+    This wooden broom, which weighs 3 pounds, functions like a mundane broom
+    until you stand astride it and speak its command word. It then hovers
+    beneath you and can be ridden through the air.
+
+    The broom has a flying speed of 50 feet and can carry up to 400 pounds.
+    While carrying more than 200 pounds, its flying speed becomes 30 feet.
+
+    You can send the broom to travel alone to a destination within 1 mile,
+    naming a landmark and distance, provided there are no obstacles in the
+    way. The broom can be called back with another command word while within
+    1 mile.
+  rarity: Uncommon
+  item_type: Wondrous item
+  passive_effect_description: Grants flight (50 ft; 30 ft when carrying over 200 lb)
+
 - class_name: CharlatansDie
   name: Charlatan's Die
   description: |

--- a/tests/test_magic_items_yaml.py
+++ b/tests/test_magic_items_yaml.py
@@ -44,13 +44,26 @@ class TestYamlBackedMagicItems(TestCase):
         self.assertEqual(item.weapon_attack_bonus_total(), 1)
         self.assertEqual(item.weapon_damage_bonus_total(), 1)
 
+    def test_broom_of_flying_loaded_from_yaml(self):
+        """Broom of Flying should expose YAML-backed item metadata and passive effects."""
+        self.assertEqual(magic_items.BroomOfFlying.data_source, "yaml")
+        self.assertEqual(magic_items.BroomOfFlying.rarity, "Uncommon")
+
+        item = magic_items.BroomOfFlying()
+        self.assertEqual(item.item_type, "Wondrous item")
+        passive_effects = [e for e in item.all_effects if isinstance(e, magic_items.PassiveEffect)]
+        self.assertEqual(len(passive_effects), 1)
+        self.assertIn("Grants flight", passive_effects[0].description)
+
     def test_registry_finds_yaml_items(self):
         """Registry lookups should resolve YAML-backed magic item classes."""
         shield_scroll_cls = find_content("scroll of shield")
         cloak_cls = find_content("cloak of protection")
+        broom_cls = find_content("broom of flying")
 
         self.assertIs(shield_scroll_cls, magic_items.ScrollOfShield)
         self.assertIs(cloak_cls, magic_items.CloakOfProtection)
+        self.assertIs(broom_cls, magic_items.BroomOfFlying)
 
     def test_all_items_now_use_yaml(self):
         """All items should now come from YAML definitions."""


### PR DESCRIPTION
## Summary
- add YAML-backed `BroomOfFlying` magic item to `dungeonsheets/data/magic_items.yaml`
- include rarity, item type, and sheet-facing flight/carrying-capacity notes
- extend YAML magic item tests to validate item loading and content registry resolution

## Validation
- `uv run pytest tests/test_magic_items.py tests/test_magic_items_yaml.py`
- `uv run ruff check tests/test_magic_items_yaml.py`
- `uv run ruff format --check tests/test_magic_items_yaml.py`
