### PR TITLE
Support spell-linked item spellcasting (#45)

### DIFF
--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -536,11 +536,17 @@ class Character(Creature):
         # Include spells granted by magic items (e.g., scrolls, staffs)
         if hasattr(self, "magic_items"):
             for item in self.magic_items:
-                try:
-                    spells |= set(item.granted_spell_classes())
-                except (AttributeError, Exception):
-                    # Item doesn't grant spells or resolution failed; skip it
-                    pass
+                granted_spell_classes = getattr(item, "granted_spell_classes", None)
+                if granted_spell_classes is None:
+                    continue
+                if not callable(granted_spell_classes):
+                    warnings.warn(
+                        f"{type(item).__name__}.granted_spell_classes is not callable; "
+                        "skipping granted spells for this item.",
+                        stacklevel=2,
+                    )
+                    continue
+                spells |= {cls() for cls in granted_spell_classes()}
         return sorted(tuple(spells), key=(lambda x: x.name))
 
     @property

--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -533,6 +533,14 @@ class Character(Creature):
             spells |= set(f.spells_known) | set(f.spells_prepared)
         for c in self.spellcasting_classes:
             spells |= set(c.spells_known) | set(c.spells_prepared)
+        # Include spells granted by magic items (e.g., scrolls, staffs)
+        if hasattr(self, "magic_items"):
+            for item in self.magic_items:
+                try:
+                    spells |= set(item.granted_spell_classes())
+                except (AttributeError, Exception):
+                    # Item doesn't grant spells or resolution failed; skip it
+                    pass
         return sorted(tuple(spells), key=(lambda x: x.name))
 
     @property

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -301,6 +301,39 @@ class DruidTestCase(TestCase):
         self.assertEqual(len(char.spells), 2)
         self.assertIn(spells.Druidcraft(), char.spells)
 
+    def test_spells_from_magic_items(self):
+        """Characters should have access to spells granted by magic items.
+
+        When a character has a magic item that grants spells (e.g., a spell scroll
+        or staff), those spells should be included in the character's available
+        spells list.
+        """
+        char = Wizard()
+        char.level = 3
+        # Add a scroll of shield using set_attrs to properly instantiate it
+        char.set_attrs(magic_items=["scroll of shield"])
+        # Verify shield spell is in character's available spells
+        spell_names = [s.name for s in char.spells]
+        self.assertIn("Shield", spell_names)
+        # Verify the Shield spell is in the list
+        shield_spells = [s for s in char.spells if s.name == "Shield"]
+        self.assertEqual(len(shield_spells), 1)
+        # Shield spell class should be the shield spell
+        self.assertIs(shield_spells[0], spells.Shield)
+
+    def test_spells_from_multiple_magic_items(self):
+        """Characters should aggregate spells from multiple magic items."""
+        char = Wizard()
+        char.level = 5
+        # Add Staff of Spells which grants multiple spells
+        char.set_attrs(magic_items=["staff of spells"])
+        spell_names = [s.name for s in char.spells]
+        # Staff of Spells grants: Magic Missile, Fireball, Lightning Bolt, Polymorph
+        staff_spells = {"Magic Missile", "Fireball", "Lightning Bolt", "Polymorph"}
+        found_spells = set(spell_names)
+        # Check that at least some staff spells are present
+        self.assertTrue(found_spells & staff_spells, f"Staff spells not found. Got: {spell_names}")
+
     def test_wild_shapes(self):
         char = Druid()
         # Druid level 2

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -315,24 +315,23 @@ class DruidTestCase(TestCase):
         # Verify shield spell is in character's available spells
         spell_names = [s.name for s in char.spells]
         self.assertIn("Shield", spell_names)
-        # Verify the Shield spell is in the list
+        # Verify the Shield spell is in the list as an instance
         shield_spells = [s for s in char.spells if s.name == "Shield"]
         self.assertEqual(len(shield_spells), 1)
-        # Shield spell class should be the shield spell
-        self.assertIs(shield_spells[0], spells.Shield)
+        self.assertIsInstance(shield_spells[0], spells.Shield)
 
     def test_spells_from_multiple_magic_items(self):
-        """Characters should aggregate spells from multiple magic items."""
+        """Characters should aggregate spells from all magic items and expose the full set."""
         char = Wizard()
         char.level = 5
-        # Add Staff of Spells which grants multiple spells
-        char.set_attrs(magic_items=["staff of spells"])
+        # Staff of Spells grants 4 spells; adding it and a scroll exercises aggregation
+        char.set_attrs(magic_items=["staff of spells", "scroll of shield"])
         spell_names = [s.name for s in char.spells]
         # Staff of Spells grants: Magic Missile, Fireball, Lightning Bolt, Polymorph
-        staff_spells = {"Magic Missile", "Fireball", "Lightning Bolt", "Polymorph"}
-        found_spells = set(spell_names)
-        # Check that at least some staff spells are present
-        self.assertTrue(found_spells & staff_spells, f"Staff spells not found. Got: {spell_names}")
+        # Scroll of Shield grants: Shield
+        expected_spells = {"Magic Missile", "Fireball", "Lightning Bolt", "Polymorph", "Shield"}
+        missing = expected_spells - set(spell_names)
+        self.assertFalse(missing, f"Expected spells not found: {missing}. Got: {spell_names}")
 
     def test_wild_shapes(self):
         char = Druid()


### PR DESCRIPTION
## Overview
Adds support for magic items with linked spells to contribute their spells to the character's available spells list.

## Changes
- Modified `Character.spells` property to include spells granted by magic items (scrolls, staffs, etc.)
- Added error handling for items without spell-granting capabilities
- Added comprehensive tests for single and multiple spell-granting items

## Testing
- All 48 existing tests pass (no regressions)
- 2 new tests added:
  - `test_spells_from_magic_items`: Verifies single scroll adds Shield spell
  - `test_spells_from_multiple_magic_items`: Verifies Staff of Spells grants all 4 linked spells

## Related Issue
Resolves #45 (Phase 4b - spell-based item support)