### PR TITLE
feat: support spell-linked items and dynamic spell scrolls

### DIFF
--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -536,11 +536,17 @@ class Character(Creature):
         # Include spells granted by magic items (e.g., scrolls, staffs)
         if hasattr(self, "magic_items"):
             for item in self.magic_items:
-                try:
-                    spells |= set(item.granted_spell_classes())
-                except (AttributeError, Exception):
-                    # Item doesn't grant spells or resolution failed; skip it
-                    pass
+                granted_spell_classes = getattr(item, "granted_spell_classes", None)
+                if granted_spell_classes is None:
+                    continue
+                if not callable(granted_spell_classes):
+                    warnings.warn(
+                        f"{type(item).__name__}.granted_spell_classes is not callable; "
+                        "skipping granted spells for this item.",
+                        stacklevel=2,
+                    )
+                    continue
+                spells |= {cls() for cls in granted_spell_classes()}
         return sorted(tuple(spells), key=(lambda x: x.name))
 
     @property

--- a/dungeonsheets/character.py
+++ b/dungeonsheets/character.py
@@ -533,6 +533,14 @@ class Character(Creature):
             spells |= set(f.spells_known) | set(f.spells_prepared)
         for c in self.spellcasting_classes:
             spells |= set(c.spells_known) | set(c.spells_prepared)
+        # Include spells granted by magic items (e.g., scrolls, staffs)
+        if hasattr(self, "magic_items"):
+            for item in self.magic_items:
+                try:
+                    spells |= set(item.granted_spell_classes())
+                except (AttributeError, Exception):
+                    # Item doesn't grant spells or resolution failed; skip it
+                    pass
         return sorted(tuple(spells), key=(lambda x: x.name))
 
     @property

--- a/dungeonsheets/content_registry.py
+++ b/dungeonsheets/content_registry.py
@@ -125,6 +125,28 @@ class ContentRegistry:
                     for v, attr in zip(is_valid, found_attrs)
                 ]
             found_attrs = [attr for attr, v in zip(found_attrs, is_valid) if v]
+        # Fallback: dynamically create a SpellScroll for "scroll of <spell>" patterns
+        if len(found_attrs) == 0 and py_name.lower().startswith("scroll_of_"):
+            spell_part = py_name[len("scroll_of_") :].replace("_", " ")
+            # Late import to avoid circular dependency at module level
+            from dungeonsheets.magic_items import SpellScroll
+
+            is_valid_for_magic_item = len(valid_classes) == 0 or any(
+                issubclass(SpellScroll, cls) for cls in valid_classes if isinstance(cls, type)
+            )
+            if is_valid_for_magic_item:
+                return SpellScroll.scroll_for(spell_part)
+        # Fallback: dynamically create a SpellScroll for "scroll of <spell>" patterns
+        if len(found_attrs) == 0 and py_name.lower().startswith("scroll_of_"):
+            spell_part = py_name[len("scroll_of_") :].replace("_", " ")
+            # Late import to avoid circular dependency at module level
+            from dungeonsheets.magic_items import SpellScroll
+
+            is_valid_for_magic_item = len(valid_classes) == 0 or any(
+                issubclass(SpellScroll, cls) for cls in valid_classes if isinstance(cls, type)
+            )
+            if is_valid_for_magic_item:
+                return SpellScroll.scroll_for(spell_part)
         # Check that we found a valid, unique attribute
         if len(found_attrs) == 0:
             raise exceptions.ContentNotFound(f"Modules {self.modules} have no attribute {name}")

--- a/dungeonsheets/content_registry.py
+++ b/dungeonsheets/content_registry.py
@@ -135,18 +135,11 @@ class ContentRegistry:
                 issubclass(SpellScroll, cls) for cls in valid_classes if isinstance(cls, type)
             )
             if is_valid_for_magic_item:
-                return SpellScroll.scroll_for(spell_part)
-        # Fallback: dynamically create a SpellScroll for "scroll of <spell>" patterns
-        if len(found_attrs) == 0 and py_name.lower().startswith("scroll_of_"):
-            spell_part = py_name[len("scroll_of_") :].replace("_", " ")
-            # Late import to avoid circular dependency at module level
-            from dungeonsheets.magic_items import SpellScroll
-
-            is_valid_for_magic_item = len(valid_classes) == 0 or any(
-                issubclass(SpellScroll, cls) for cls in valid_classes if isinstance(cls, type)
-            )
-            if is_valid_for_magic_item:
-                return SpellScroll.scroll_for(spell_part)
+                try:
+                    return SpellScroll.scroll_for(spell_part)
+                except exceptions.ContentNotFound:
+                    # spell_part is not a known spell; fall through to ContentNotFound below
+                    pass
         # Check that we found a valid, unique attribute
         if len(found_attrs) == 0:
             raise exceptions.ContentNotFound(f"Modules {self.modules} have no attribute {name}")

--- a/dungeonsheets/content_registry.py
+++ b/dungeonsheets/content_registry.py
@@ -137,9 +137,10 @@ class ContentRegistry:
             if is_valid_for_magic_item:
                 try:
                     return SpellScroll.scroll_for(spell_part)
-                except exceptions.ContentNotFound:
-                    # spell_part is not a known spell; fall through to ContentNotFound below
-                    pass
+                except exceptions.ContentNotFound as exc:
+                    raise exceptions.ContentNotFound(
+                        f'"scroll of {spell_part}" could not be created: "{spell_part}" is not a known spell.'
+                    ) from exc
         # Check that we found a valid, unique attribute
         if len(found_attrs) == 0:
             raise exceptions.ContentNotFound(f"Modules {self.modules} have no attribute {name}")

--- a/dungeonsheets/forms/magic_items_template.tex
+++ b/dungeonsheets/forms/magic_items_template.tex
@@ -3,7 +3,7 @@
 [% if use_dnd_decorations %]
   [% for mitem in character.magic_items %]
     \pdfbookmark[1]{[[ mitem.name ]]}{Magic Items - [[ mitem.name ]]}
-        \DndItemHeader{[[ mitem.name ]]}{[%- if mitem.item_type -%][[ mitem.item_type ]], [[ mitem.rarity.lower() ]]
+        \DndItemHeader{[[ mitem.name ]]}{[%- if mitem.item_type_display -%][[ mitem.item_type_display ]], [[ mitem.rarity.lower() ]]
                                          [%- else -%][[ mitem.rarity ]] item[%- endif -%]
                                          [% if mitem.requires_attunement %] (requires attunement)[% endif %]}
         [%- if mitem.needs_implementation %]

--- a/dungeonsheets/magic_items.py
+++ b/dungeonsheets/magic_items.py
@@ -370,6 +370,27 @@ class MagicItem:
         spell_effects = [e.spell for e in self._effects if isinstance(e, SpellGrantedEffect)]
         return tuple(spell_effects)
 
+    @property
+    def item_type_display(self) -> str:
+        """Human-readable item type, including linked spell details when present.
+
+        Returns
+        -------
+        str
+            Display label for the item type. For spell-granting items this
+            includes the linked spell names, e.g. ``"Scroll (Charm Person)"``.
+        """
+        base = self.item_type or ""
+        if not base:
+            return ""
+
+        spell_names = self.granted_spell_names
+        if len(spell_names) == 0:
+            return base
+
+        pretty_spells = ", ".join(name.replace("_", " ").title() for name in spell_names)
+        return f"{base} ({pretty_spells})"
+
     def granted_spell_classes(self):
         """Resolve granted spell names to their Spell class definitions.
 

--- a/dungeonsheets/magic_items.py
+++ b/dungeonsheets/magic_items.py
@@ -470,6 +470,49 @@ class SpellScroll(MagicItem):
     item_type = "Scroll"
     form = MagicItemForm(kind="scroll", base_item="Scroll", is_consumable=True)
 
+    @classmethod
+    def scroll_for(cls, spell_name: str) -> type:
+        """Dynamically create a SpellScroll subclass for any spell by name.
+
+        Analogous to ``Weapon.improved_version()``: resolves the spell name
+        via the content registry to validate it exists, then returns a new
+        ``SpellScroll`` subclass with that spell linked.
+
+        Parameters
+        ----------
+        spell_name : str
+            The spell name as it would appear in a character file
+            (e.g. ``"fireball"``, ``"charm person"``).
+
+        Returns
+        -------
+        type[SpellScroll]
+            A ``SpellScroll`` subclass whose ``linked_spells`` contains
+            *spell_name* and whose ``name`` is ``"Scroll of <Title>"``.  The
+            spell is validated via ``find_content`` so unknown names still
+            raise ``ContentNotFound``.
+        """
+        from dungeonsheets import spells as _spells
+        from dungeonsheets.content_registry import find_content
+
+        # Validate the spell exists — raises ContentNotFound for unknown spells
+        find_content(spell_name, valid_classes=[_spells.Spell])
+
+        title = spell_name.replace("_", " ").title()
+        camel = "".join(
+            s.capitalize() for s in spell_name.replace("-", " ").replace("_", " ").split()
+        )
+
+        new_cls = type(
+            f"ScrollOf{camel}",
+            (cls,),
+            {
+                "name": f"Scroll of {title}",
+                "linked_spells": (spell_name,),
+            },
+        )
+        return new_cls
+
 
 globals().update(
     load_yaml_magic_item_classes(

--- a/dungeonsheets/magic_items.py
+++ b/dungeonsheets/magic_items.py
@@ -517,11 +517,31 @@ class SpellScroll(MagicItem):
         from dungeonsheets.content_registry import find_content
 
         # Validate the spell exists — raises ContentNotFound for unknown spells
-        find_content(spell_name, valid_classes=[_spells.Spell])
+        spell_cls = find_content(spell_name, valid_classes=[_spells.Spell])
+
+        # Derive rarity from spell level per the PHB Spell Scroll table
+        _SCROLL_RARITY = {
+            0: "Common",
+            1: "Common",
+            2: "Uncommon",
+            3: "Uncommon",
+            4: "Rare",
+            5: "Rare",
+            6: "Very Rare",
+            7: "Very Rare",
+            8: "Very Rare",
+            9: "Legendary",
+        }
+        spell_level = getattr(spell_cls, "level", 0)
+        rarity = _SCROLL_RARITY.get(spell_level, "Common")
 
         title = spell_name.replace("_", " ").title()
         camel = "".join(
             s.capitalize() for s in spell_name.replace("-", " ").replace("_", " ").split()
+        )
+        docstring = (
+            f"A spell scroll containing the {title} spell (level {spell_level}). "
+            "A scroll crumbles to dust after a single use."
         )
 
         new_cls = type(
@@ -530,6 +550,8 @@ class SpellScroll(MagicItem):
             {
                 "name": f"Scroll of {title}",
                 "linked_spells": (spell_name,),
+                "rarity": rarity,
+                "__doc__": docstring,
             },
         )
         return new_cls

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -301,6 +301,39 @@ class DruidTestCase(TestCase):
         self.assertEqual(len(char.spells), 2)
         self.assertIn(spells.Druidcraft(), char.spells)
 
+    def test_spells_from_magic_items(self):
+        """Characters should have access to spells granted by magic items.
+
+        When a character has a magic item that grants spells (e.g., a spell scroll
+        or staff), those spells should be included in the character's available
+        spells list.
+        """
+        char = Wizard()
+        char.level = 3
+        # Add a scroll of shield using set_attrs to properly instantiate it
+        char.set_attrs(magic_items=["scroll of shield"])
+        # Verify shield spell is in character's available spells
+        spell_names = [s.name for s in char.spells]
+        self.assertIn("Shield", spell_names)
+        # Verify the Shield spell is in the list
+        shield_spells = [s for s in char.spells if s.name == "Shield"]
+        self.assertEqual(len(shield_spells), 1)
+        # Shield spell class should be the shield spell
+        self.assertIs(shield_spells[0], spells.Shield)
+
+    def test_spells_from_multiple_magic_items(self):
+        """Characters should aggregate spells from multiple magic items."""
+        char = Wizard()
+        char.level = 5
+        # Add Staff of Spells which grants multiple spells
+        char.set_attrs(magic_items=["staff of spells"])
+        spell_names = [s.name for s in char.spells]
+        # Staff of Spells grants: Magic Missile, Fireball, Lightning Bolt, Polymorph
+        staff_spells = {"Magic Missile", "Fireball", "Lightning Bolt", "Polymorph"}
+        found_spells = set(spell_names)
+        # Check that at least some staff spells are present
+        self.assertTrue(found_spells & staff_spells, f"Staff spells not found. Got: {spell_names}")
+
     def test_wild_shapes(self):
         char = Druid()
         # Druid level 2

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -315,24 +315,23 @@ class DruidTestCase(TestCase):
         # Verify shield spell is in character's available spells
         spell_names = [s.name for s in char.spells]
         self.assertIn("Shield", spell_names)
-        # Verify the Shield spell is in the list
+        # Verify the Shield spell is in the list as an instance
         shield_spells = [s for s in char.spells if s.name == "Shield"]
         self.assertEqual(len(shield_spells), 1)
-        # Shield spell class should be the shield spell
-        self.assertIs(shield_spells[0], spells.Shield)
+        self.assertIsInstance(shield_spells[0], spells.Shield)
 
     def test_spells_from_multiple_magic_items(self):
-        """Characters should aggregate spells from multiple magic items."""
+        """Characters should aggregate spells from all magic items and expose the full set."""
         char = Wizard()
         char.level = 5
-        # Add Staff of Spells which grants multiple spells
-        char.set_attrs(magic_items=["staff of spells"])
+        # Staff of Spells grants 4 spells; adding it and a scroll exercises aggregation
+        char.set_attrs(magic_items=["staff of spells", "scroll of shield"])
         spell_names = [s.name for s in char.spells]
         # Staff of Spells grants: Magic Missile, Fireball, Lightning Bolt, Polymorph
-        staff_spells = {"Magic Missile", "Fireball", "Lightning Bolt", "Polymorph"}
-        found_spells = set(spell_names)
-        # Check that at least some staff spells are present
-        self.assertTrue(found_spells & staff_spells, f"Staff spells not found. Got: {spell_names}")
+        # Scroll of Shield grants: Shield
+        expected_spells = {"Magic Missile", "Fireball", "Lightning Bolt", "Polymorph", "Shield"}
+        missing = expected_spells - set(spell_names)
+        self.assertFalse(missing, f"Expected spells not found: {missing}. Got: {spell_names}")
 
     def test_wild_shapes(self):
         char = Druid()

--- a/tests/test_magic_items_phase3.py
+++ b/tests/test_magic_items_phase3.py
@@ -2,8 +2,9 @@
 
 import unittest
 
-from dungeonsheets import magic_items
+from dungeonsheets import magic_items, spells
 from dungeonsheets.content_registry import find_content
+from dungeonsheets.exceptions import ContentNotFound
 
 
 class PhaseThreeItemTests(unittest.TestCase):
@@ -61,3 +62,48 @@ class PhaseThreeItemTests(unittest.TestCase):
         self.assertEqual(item.name, "Staff of Spells")
         self.assertEqual(item.rarity, "Very Rare")
         self.assertTrue(item.requires_attunement)
+
+
+class DynamicSpellScrollTests(unittest.TestCase):
+    """Test dynamic creation of spell scrolls via 'scroll of <spell>' lookup."""
+
+    def test_scroll_of_fireball_resolves_via_registry(self):
+        """'scroll of fireball' should resolve to a SpellScroll for Fireball."""
+        item_cls = find_content("scroll of fireball")
+        self.assertTrue(issubclass(item_cls, magic_items.SpellScroll))
+        item = item_cls()
+        self.assertEqual(item.name, "Scroll of Fireball")
+        self.assertIn("fireball", item.granted_spell_names)
+        spell_classes = item.granted_spell_classes()
+        self.assertEqual(len(spell_classes), 1)
+        self.assertIs(spell_classes[0], spells.Fireball)
+
+    def test_scroll_of_charm_person_resolves_via_registry(self):
+        """'scroll of charm person' should resolve to a SpellScroll for Charm Person."""
+        item_cls = find_content("scroll of charm person")
+        self.assertTrue(issubclass(item_cls, magic_items.SpellScroll))
+        item = item_cls()
+        self.assertIn("charm person", item.granted_spell_names)
+        spell_classes = item.granted_spell_classes()
+        self.assertEqual(len(spell_classes), 1)
+        self.assertIs(spell_classes[0], spells.CharmPerson)
+
+    def test_scroll_is_consumable(self):
+        """Dynamically created scrolls should be marked as consumable."""
+        item_cls = find_content("scroll of fireball")
+        item = item_cls()
+        self.assertEqual(item.item_type, "Scroll")
+        self.assertTrue(item.form.is_consumable)
+
+    def test_scroll_for_unknown_spell_raises_content_not_found(self):
+        """'scroll of notarealspell' should raise ContentNotFound."""
+        with self.assertRaises(ContentNotFound):
+            find_content("scroll of notarealspell")
+
+    def test_scroll_for_classmethod_returns_subclass(self):
+        """SpellScroll.scroll_for() returns a SpellScroll subclass with spell linked."""
+        cls = magic_items.SpellScroll.scroll_for("magic missile")
+        self.assertTrue(issubclass(cls, magic_items.SpellScroll))
+        item = cls()
+        self.assertIn("magic missile", item.granted_spell_names)
+        self.assertEqual(item.name, "Scroll of Magic Missile")

--- a/tests/test_magic_items_phase3.py
+++ b/tests/test_magic_items_phase3.py
@@ -77,6 +77,9 @@ class DynamicSpellScrollTests(unittest.TestCase):
         spell_classes = item.granted_spell_classes()
         self.assertEqual(len(spell_classes), 1)
         self.assertIs(spell_classes[0], spells.Fireball)
+        # Fireball is 3rd-level → Uncommon
+        self.assertEqual(item.rarity, "Uncommon")
+        self.assertIn("Fireball", item.__doc__)
 
     def test_scroll_of_charm_person_resolves_via_registry(self):
         """'scroll of charm person' should resolve to a SpellScroll for Charm Person."""
@@ -87,6 +90,8 @@ class DynamicSpellScrollTests(unittest.TestCase):
         spell_classes = item.granted_spell_classes()
         self.assertEqual(len(spell_classes), 1)
         self.assertIs(spell_classes[0], spells.CharmPerson)
+        # Charm Person is 1st-level → Common
+        self.assertEqual(item.rarity, "Common")
 
     def test_scroll_is_consumable(self):
         """Dynamically created scrolls should be marked as consumable."""
@@ -96,9 +101,10 @@ class DynamicSpellScrollTests(unittest.TestCase):
         self.assertTrue(item.form.is_consumable)
 
     def test_scroll_for_unknown_spell_raises_content_not_found(self):
-        """'scroll of notarealspell' should raise ContentNotFound."""
-        with self.assertRaises(ContentNotFound):
+        """'scroll of notarealspell' should raise ContentNotFound with a useful message."""
+        with self.assertRaises(ContentNotFound) as ctx:
             find_content("scroll of notarealspell")
+        self.assertIn("notarealspell", str(ctx.exception))
 
     def test_scroll_for_classmethod_returns_subclass(self):
         """SpellScroll.scroll_for() returns a SpellScroll subclass with spell linked."""

--- a/tests/test_make_sheets.py
+++ b/tests/test_make_sheets.py
@@ -1,10 +1,9 @@
-import unittest
 import os
+import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from dungeonsheets import make_sheets, character, monsters, random_tables
-
+from dungeonsheets import character, make_sheets, monsters, random_tables
 
 EG_DIR = Path(__file__).parent.parent.resolve() / "examples"
 CHARFILE = EG_DIR / "rogue1.py"
@@ -375,13 +374,27 @@ class TexCreatorTestCase(unittest.TestCase):
         self.assertIn(r"\section*{Magic Items}", tex)
         self.assertIn(r"\subsection*{Cloak of Protection}", tex)
 
+    def test_create_magic_items_tex_scroll_includes_spell_name(self):
+        char = character.Character(
+            name="Scroll Tester",
+            classes=["Wizard"],
+            levels=[1],
+            magic_items=["scroll of charm person"],
+        )
+        tex = make_sheets.create_magic_items_content(
+            character=char,
+            content_suffix="tex",
+            use_dnd_decorations=True,
+        )
+        self.assertIn("Scroll (Charm Person),", tex)
+
     def test_create_spellbook_tex(self):
         char = self.new_character()
         tex = make_sheets.create_spellbook_content(character=char, content_suffix="tex")
         self.assertIn(r"\section*{Spells}", tex)
         self.assertIn(r"\section*{Invisibility}", tex)
 
-    def test_create_spellbook_tex(self):
+    def test_create_spellbook_tex_by_level(self):
         char = self.new_character()
         tex = make_sheets.create_spellbook_content(
             character=char, content_suffix="tex", spell_order=True


### PR DESCRIPTION
## Summary
- aggregate spells granted by magic items into `Character.spells`
- add dynamic `scroll of <spell>` resolution for any valid spell name
- include linked spell names in rendered magic item headers (e.g. `Scroll (Charm Person)`)
- add regression coverage for item-spell aggregation, dynamic scroll resolution, and TeX rendering

## Key fixes
- instantiate spell classes correctly when aggregating item-granted spells
- avoid broad exception swallowing in magic-item spell aggregation path
- prevent duplicate scroll fallback logic and preserve `ContentNotFound` behavior for invalid spell names

## Validation
- `uv run pytest tests/ -q --tb=short`
- `uv run pytest tests/test_make_sheets.py::TexCreatorTestCase::test_create_magic_items_tex_scroll_includes_spell_name tests/test_magic_items_phase3.py -q --tb=short`

## Context
This branch also includes the follow-up UX fix requested after container validation: magic item summary output now includes the linked spell details for scrolls.